### PR TITLE
Fix TS-Error

### DIFF
--- a/packages/plugin-nestjs/src/types.ts
+++ b/packages/plugin-nestjs/src/types.ts
@@ -17,7 +17,7 @@ export type RootAsyncRegisterOptions =
   | IdempotencyPluginOptions
   | (Pick<ModuleMetadata, "imports"> & {
       useFactory?: (
-        ...args: unknown[]
+        ...args: any[]
       ) => Promise<IdempotencyPluginOptions> | IdempotencyPluginOptions;
       inject?: Array<InjectionToken | OptionalFactoryDependency>;
     });


### PR DESCRIPTION
TS2322: Type
(config: ConfigType<typeof idempotencyConfig>) => IdempotencyPluginOptions is not assignable to type
(...args: unknown[]) => IdempotencyPluginOptions | Promise<IdempotencyPluginOptions>
Types of parameters config and args are incompatible. Type unknown is not assignable to type
Readonly<{   REDIS_URL: string; } & CleanedEnvAccessors>