### PR TITLE
Don't return cached errors, allow to retry

### DIFF
--- a/packages/core/src/idempotency.ts
+++ b/packages/core/src/idempotency.ts
@@ -142,15 +142,19 @@ export class Idempotency {
             "A request is outstanding for this Idempotency-Key",
             IdempotencyErrorCodes.REQUEST_IN_PROGRESS,
           );
-        } else {
-          if (fingerPrint !== data.fingerPrint) {
-            throw new IdempotencyError(
-              "Idempotency-Key is already used",
-              IdempotencyErrorCodes.IDEMPOTENCY_FINGERPRINT_MISSMATCH,
-            );
-          }
-          return data.response;
         }
+        if (fingerPrint !== data.fingerPrint) {
+          throw new IdempotencyError(
+            "Idempotency-Key is already used",
+            IdempotencyErrorCodes.IDEMPOTENCY_FINGERPRINT_MISSMATCH,
+          );
+        }
+        if (data.response?.error) {
+          // don't return cached uncaught errors, allow to retry
+          return undefined
+        }
+
+        return data.response;
       }
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,12 @@ export interface IdempotencyOptions {
    * if set to `true` requests without idempotency key header will be rejected
    */
   enforceIdempotency?: boolean;
+  /**
+   * @defaultValue `false`
+   *
+   * if set to `true` responses with errors will not be cached
+   */
+  skipErrorsCache?: boolean;
 
   /**
    * @defaultValue `undefined`

--- a/packages/plugin-nestjs/src/interceptors/node-idempotency.interceptor.ts
+++ b/packages/plugin-nestjs/src/interceptors/node-idempotency.interceptor.ts
@@ -184,12 +184,6 @@ export class NodeIdempotencyInterceptor implements NestInterceptor {
         return response;
       }),
       catchError((err) => {
-        if (idempotencyReq.options?.skipErrorsCache) {
-          // do not cache the error itself, clear the cache key and allow subsequent requests to retry
-          this.nodeIdempotency.clearCache(idempotencyReq).catch(() => {});
-          throw err;
-        }
-
         const httpException = this.buildError(err as SerializedAPIException);
         const error = err instanceof HttpException ? err : httpException;
         const res: IdempotencyResponse = {

--- a/packages/plugin-nestjs/src/interceptors/node-idempotency.interceptor.ts
+++ b/packages/plugin-nestjs/src/interceptors/node-idempotency.interceptor.ts
@@ -184,6 +184,12 @@ export class NodeIdempotencyInterceptor implements NestInterceptor {
         return response;
       }),
       catchError((err) => {
+        if (idempotencyReq.options?.skipErrorsCache) {
+          // do not cache the error itself, clear the cache key and allow subsequent requests to retry
+          this.nodeIdempotency.clearCache(idempotencyReq).catch(() => {});
+          throw err;
+        }
+
         const httpException = this.buildError(err as SerializedAPIException);
         const error = err instanceof HttpException ? err : httpException;
         const res: IdempotencyResponse = {

--- a/packages/storage-adapter-memory/src/adapter-memory.ts
+++ b/packages/storage-adapter-memory/src/adapter-memory.ts
@@ -47,4 +47,8 @@ export class MemoryStorageAdapter implements StorageAdapter {
     }
     return val?.item;
   }
+
+  async delete(key: string): Promise<void> {
+    this.cache.delete(key);
+  }
 }

--- a/packages/storage-adapter-redis/src/adapter-redis.ts
+++ b/packages/storage-adapter-redis/src/adapter-redis.ts
@@ -50,4 +50,8 @@ export class RedisStorageAdapter implements StorageAdapter {
     const val = await this.client.get(key);
     return val ?? undefined;
   }
+
+  async delete(key: string): Promise<void> {
+    await this.client.del(key);
+  }
 }

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -6,6 +6,7 @@ export interface StorageAdapter {
   ) => Promise<boolean>;
   set: (key: string, val: string, { ttl }: { ttl?: number }) => Promise<void>;
   get: (key: string) => Promise<string | undefined>;
+  delete: (key: string) => Promise<void>;
   connect?: () => Promise<void>;
   disconnect?: () => Promise<void>;
 }


### PR DESCRIPTION
Hi!

Thanks for awesome module 👍 When doing tests I bumped into an issue, the module would cache this error.

Examples:

- database was down when trying to save something, and 5xx error was returned
- syntax error - trying to access non-existing JSON body member without checking properly

Even after error reason is gone (database is up, source code updated), this module will keep returning old cached error without ability to fix this.

Please review :)